### PR TITLE
Fix Kit Carlson and enforce 7 player max

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,8 +13,8 @@ DYNAMITE_EXPLOSION_PROB = 8 / 52
 
 def get_roles(players_count):
     """Return a shuffled list of roles for the game."""
-    if players_count < 3:
-        raise ValueError("O jogo requer no mínimo 3 jogadores.")
+    if players_count < 3 or players_count > 7:
+        raise ValueError("O jogo requer entre 3 e 7 jogadores.")
     roles = ["Sheriff"] + ["Outlaw"] * (players_count - 2) + ["Renegade"]
     random.shuffle(roles)
     return roles
@@ -253,7 +253,7 @@ def simulate_game(players_count=4, characters=None, rounds=500, roles=None):
 
 if __name__ == "__main__":
     total_games = 5000
-    players_count = int(input("Numero de jogadores (3-16): "))
+    players_count = int(input("Numero de jogadores (3-7): "))
     print("Personagens disponiveis:")
     print(", ".join(CHARACTERS))
     chars_input = input(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from utils import CHARACTER_PERKS
+from main import get_roles
+
+
+def test_kit_carlson_handles_small_deck():
+    deck = ["BANG"]
+    player = {"hand": []}
+
+    result = CHARACTER_PERKS["Kit Carlson"](player, "draw_phase", deck=deck)
+
+    assert result == "skip"
+    assert player["hand"] == ["BANG"]
+    assert deck == []
+
+
+def test_get_roles_rejects_more_than_seven_players():
+    try:
+        get_roles(8)
+        assert False, "Should have raised ValueError"
+    except ValueError:
+        pass
+

--- a/utils.py
+++ b/utils.py
@@ -126,7 +126,8 @@ def kit_carlson(player, event, deck=None, **_):
     """Looks at the top three cards and chooses two."""
     if event == "draw_phase" and deck is not None:
         cards = [draw_card(deck, []) for _ in range(3)]
-        keep = random.sample([c for c in cards if c], k=min(2, len(cards)))
+        available = [c for c in cards if c]
+        keep = random.sample(available, k=min(2, len(available)))
         for card in keep:
             player["hand"].append(card)
         for card in cards:


### PR DESCRIPTION
## Summary
- fix `Kit Carlson` ability when the deck has fewer than 3 cards
- restrict game setup to 3-7 players
- update prompt text for the player count
- add regression tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a53569e08330904aa22f91c58227