### PR TITLE
Add Flask microservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,24 @@ python main.py
 
 The script will prompt for the number of players (3 to 7) and
 optionally which characters to use.
+
+## Running as a microservice
+
+You can expose the simulation through a simple Flask API. Start the
+service with:
+
+```bash
+python service.py
+```
+
+The API exposes two endpoints:
+
+- `GET /simulate` - Run a single game. Query parameters:
+  - `players` (optional, default `4`): number of players.
+  - `characters` (optional): comma separated list of characters.
+- `GET /probability-matrix` - Generate the win/loss matrix. Parameters:
+  - `players` (optional, default `4`)
+  - `games` (optional, default `50`) number of simulations per
+    character/role pair.
+
+Both endpoints return JSON data suitable for a front‑end.

--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ import random
 # A semente fixa facilita os testes e depuracao.
 RANDOM_SEED = 42
 random.seed(RANDOM_SEED)
-import pandas as pd
 from utils import build_deck, draw_card, WEAPON_RANGES, CHARACTER_PERKS, CHARACTERS
 from targeting import select_target
 
@@ -37,6 +36,7 @@ def generate_setup(fixed_character, fixed_role, players_count):
 def compute_probability_matrix(players_count=4, games_per_combo=50):
     """Executa simulacoes em paralelo para gerar matriz de vitorias e derrotas."""
     import threading
+    import pandas as pd
 
     outcomes = {
         (char, role): {"wins": 0, "losses": 0}
@@ -254,6 +254,7 @@ def simulate_game(players_count=4, characters=None, rounds=500, roles=None):
     return "Draw", players
 
 if __name__ == "__main__":
+    import pandas as pd
     total_games = 5000
     players_count = int(input("Numero de jogadores (3-7): "))
     if not 3 <= players_count <= 7:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pandas
+Flask

--- a/service.py
+++ b/service.py
@@ -1,0 +1,32 @@
+from flask import Flask, request, jsonify
+from main import simulate_game, compute_probability_matrix
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return jsonify({'message': 'Bang! Simulation Service'})
+
+@app.route('/simulate')
+def simulate_route():
+    try:
+        players = int(request.args.get('players', 4))
+    except ValueError:
+        return jsonify({'error': 'Invalid players parameter'}), 400
+    chars = request.args.get('characters')
+    characters = [c.strip() for c in chars.split(',')] if chars else None
+    winner, players_data = simulate_game(players, characters)
+    return jsonify({'winner': winner, 'players': players_data})
+
+@app.route('/probability-matrix')
+def matrix_route():
+    try:
+        players = int(request.args.get('players', 4))
+        games = int(request.args.get('games', 50))
+    except ValueError:
+        return jsonify({'error': 'Invalid query parameters'}), 400
+    df = compute_probability_matrix(players_count=players, games_per_combo=games)
+    return jsonify(df.to_dict(orient='records'))
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add minimal Flask service to expose simulation functions
- make pandas a lazy import to allow testing without the library
- document how to run the service
- include Flask in requirements

## Testing
- `python3 tests/test_utils.py`
- `python3 tests/test_perks.py`


------
https://chatgpt.com/codex/tasks/task_e_6855a9e8e44c8330adf09bafe3d077dd