### PR TITLE
Add simple web UI for Bang simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-__pycache__/targeting.cpython-313.pyc
-__pycache__/utils.cpython-313.pyc
+__pycache__/
+tests/__pycache__/

--- a/README.md
+++ b/README.md
@@ -25,12 +25,15 @@ optionally which characters to use.
 
 ## Running as a microservice
 
-You can expose the simulation through a simple Flask API. Start the
-service with:
+You can expose the simulation through a simple Flask API with a small
+web interface. Start the service with:
 
 ```bash
 python service.py
 ```
+
+After starting, open `http://localhost:5000/` in your browser to use the
+interactive front‑end.
 
 The API exposes two endpoints:
 

--- a/service.py
+++ b/service.py
@@ -1,11 +1,13 @@
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, render_template
 from main import simulate_game, compute_probability_matrix
+from utils import CHARACTERS
 
 app = Flask(__name__)
 
 @app.route('/')
 def index():
-    return jsonify({'message': 'Bang! Simulation Service'})
+    """Render a simple HTML front-end for the simulation."""
+    return render_template('index.html', characters=CHARACTERS)
 
 @app.route('/simulate')
 def simulate_route():

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Bang! Simulação</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        label { display: block; margin-top: 1em; }
+        select { width: 200px; height: 150px; }
+        button { margin-top: 1em; padding: 0.5em 1em; }
+        pre { background: #f0f0f0; padding: 1em; }
+    </style>
+</head>
+<body>
+<h1>Simulação do Bang!</h1>
+<form id="simulate-form">
+    <label>Número de jogadores:
+        <input type="number" id="players" min="3" max="7" value="4" required>
+    </label>
+    <label>Personagens (selecione um ou mais):
+        <select id="characters" multiple>
+            {% for char in characters %}
+            <option value="{{ char }}">{{ char }}</option>
+            {% endfor %}
+        </select>
+    </label>
+    <button type="submit">Simular</button>
+</form>
+<pre id="result"></pre>
+<script>
+    document.getElementById('simulate-form').addEventListener('submit', async function(e) {
+        e.preventDefault();
+        const players = document.getElementById('players').value;
+        const selected = Array.from(document.getElementById('characters').selectedOptions)
+            .map(o => o.value).join(',');
+        const query = new URLSearchParams({players: players});
+        if (selected) query.append('characters', selected);
+        const response = await fetch('/simulate?' + query.toString());
+        const data = await response.json();
+        document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a tiny web frontend served by Flask
- update ignore rules for bytecode folders
- document the web interface in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855af899180833086e0b926be557e88