### PR TITLE
Improve logging and enforce character selection count

### DIFF
--- a/main.py
+++ b/main.py
@@ -133,7 +133,7 @@ def compute_statistics(players_count=4, games=500):
         "probability_matrix": prob.to_dict(orient="records"),
     }
 
-def simulate_game(players_count=4, characters=None, rounds=500, roles=None, return_log=False):
+def simulate_game(players_count=4, characters=None, rounds=500, roles=None, return_log=False, game_number=1):
     """Simula uma partida e retorna o time vencedor e os jogadores.
 
     Quando ``return_log`` é ``True`` uma lista de eventos da partida é
@@ -188,7 +188,9 @@ def simulate_game(players_count=4, characters=None, rounds=500, roles=None, retu
             if not player["alive"]:
                 continue
             if return_log:
-                log.append(f"Rodada {round_ + 1} - turno de {player['character']}")
+                log.append(
+                    f"Partida {game_number} - Rodada {round_ + 1} - turno de {player['character']}"
+                )
 
             # habilidades no inicio do turno
             CHARACTER_PERKS[player["character"]](player, "turn_start", discard=discard)
@@ -265,7 +267,9 @@ def simulate_game(players_count=4, characters=None, rounds=500, roles=None, retu
                 if not target:
                     continue
                 if return_log:
-                    log.append(f"{player['character']} atacou {target['character']}")
+                    log.append(
+                        f"Partida {game_number} - Rodada {round_ + 1} - {player['character']} atacou {target['character']}"
+                    )
                 player["hand"].remove(use_card)
                 discard.append(use_card)
 
@@ -287,7 +291,7 @@ def simulate_game(players_count=4, characters=None, rounds=500, roles=None, retu
                     target["hp"] -= 1
                     if return_log:
                         log.append(
-                            f"{target['character']} perdeu 1 de vida (hp={target['hp']})"
+                            f"Partida {game_number} - Rodada {round_ + 1} - {target['character']} perdeu 1 de vida (hp={target['hp']})"
                         )
                     if target["character"] == "Bart Cassidy":
                         CHARACTER_PERKS[target["character"]](target, "damaged", deck=deck, discard=discard)
@@ -296,7 +300,9 @@ def simulate_game(players_count=4, characters=None, rounds=500, roles=None, retu
                     if target["hp"] <= 0:
                         target["alive"] = False
                         if return_log:
-                            log.append(f"{target['character']} morreu")
+                            log.append(
+                                f"Partida {game_number} - Rodada {round_ + 1} - {target['character']} morreu"
+                            )
 
             # Limite de cartas
             while len(player["hand"]) > player["hp"]:
@@ -321,12 +327,12 @@ def simulate_game(players_count=4, characters=None, rounds=500, roles=None, retu
 
         if winner:
             if return_log:
-                log.append(f"Vencedor: {winner}")
+                log.append(f"Partida {game_number} - Vencedor: {winner}")
                 return winner, players, log
             return winner, players
 
     if return_log:
-        log.append("Vencedor: Draw")
+        log.append(f"Partida {game_number} - Vencedor: Draw")
         return "Draw", players, log
 
     return "Draw", players

--- a/service.py
+++ b/service.py
@@ -17,7 +17,7 @@ def simulate_route():
         return jsonify({'error': 'Invalid players parameter'}), 400
     chars = request.args.get('characters')
     characters = [c.strip() for c in chars.split(',')] if chars else None
-    winner, players_data, log = simulate_game(players, characters, return_log=True)
+    winner, players_data, log = simulate_game(players, characters, return_log=True, game_number=1)
     return jsonify({'winner': winner, 'players': players_data, 'log': log})
 
 @app.route('/probability-matrix')

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,12 +20,15 @@
     <label>Número de jogadores:
         <input type="number" id="players" min="3" max="7" value="4" required>
     </label>
-    <label>Personagens (selecione um ou mais):
-        <select id="characters" multiple>
+    <label>Personagens (selecione exatamente o número de jogadores):
+        <div id="characters" style="display: flex; flex-wrap: wrap; max-width: 220px;">
             {% for char in characters %}
-            <option value="{{ char }}">{{ char }}</option>
+            <div style="width: 50%;">
+                <input type="checkbox" id="char-{{ loop.index }}" value="{{ char }}">
+                <label for="char-{{ loop.index }}">{{ char }}</label>
+            </div>
             {% endfor %}
-        </select>
+        </div>
     </label>
     <button type="submit">Simular</button>
 </form>
@@ -79,17 +82,26 @@
 
     document.getElementById('simulate-form').addEventListener('submit', async function(e) {
         e.preventDefault();
-        const players = document.getElementById('players').value;
-        const selected = Array.from(document.getElementById('characters').selectedOptions)
-            .map(o => o.value).join(',');
+        const players = parseInt(document.getElementById('players').value, 10);
+        const checkboxes = document.querySelectorAll('#characters input[type=checkbox]:checked');
+        if (checkboxes.length > 0 && checkboxes.length !== players) {
+            alert('Selecione exatamente ' + players + ' personagens');
+            return;
+        }
+        const selected = Array.from(checkboxes).map(c => c.value).join(',');
+        document.getElementById('log-table').innerHTML = '';
+        document.getElementById('matrix-table').innerHTML = '';
+        document.getElementById('details-table').innerHTML = '';
+        document.getElementById('role-table').innerHTML = '';
+
         const query = new URLSearchParams({players});
         if (selected) query.append('characters', selected);
 
-        const simRes = await fetch('/simulate?' + query.toString());
+        const simRes = await fetch('/simulate?' + query.toString(), {cache: 'no-store'});
         const simData = await simRes.json();
         renderLog(simData.log);
 
-        const statsRes = await fetch('/statistics?' + new URLSearchParams({players}).toString());
+        const statsRes = await fetch('/statistics?' + new URLSearchParams({players}).toString(), {cache: 'no-store'});
         const statsData = await statsRes.json();
         renderTable('matrix-table', statsData.probability_matrix);
         renderTable('details-table', statsData.role_character_stats);


### PR DESCRIPTION
## Summary
- use a list of checkboxes for character selection
- validate selected characters equal number of players
- clear the UI and disable caching when running a simulation
- include game number and round in action logs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b58d267c8330aa3b676d76b6b403