### PR TITLE
Add full logs to statistics endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -84,14 +84,18 @@ def compute_probability_matrix(players_count=4, games_per_combo=50):
 
 
 def compute_statistics(players_count=4, games=500):
-    """Executa multiplas partidas para gerar estatisticas agregadas."""
+    """Executa multiplas partidas e retorna estatisticas e log completo."""
     import pandas as pd
 
     results_roles = {"Sheriff": 0, "Outlaws": 0, "Renegade": 0, "Draw": 0}
     results_details = {}
+    logs = []
 
-    for _ in range(games):
-        winner, players = simulate_game(players_count)
+    for i in range(games):
+        winner, players, log = simulate_game(
+            players_count, return_log=True, game_number=i + 1
+        )
+        logs.extend(log)
         results_roles[winner] += 1
 
         if winner != "Draw":
@@ -131,6 +135,7 @@ def compute_statistics(players_count=4, games=500):
         "role_stats": df_roles.to_dict(orient="records"),
         "role_character_stats": df_details.to_dict(orient="records") if not df_details.empty else [],
         "probability_matrix": prob.to_dict(orient="records"),
+        "log": logs,
     }
 
 def simulate_game(players_count=4, characters=None, rounds=500, roles=None, return_log=False, game_number=1):

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,6 +12,7 @@
         th, td { border: 1px solid #ccc; padding: 0.25em 0.5em; text-align: center; }
         #layout { display: flex; gap: 2em; margin-top: 2em; }
         #log-container { max-height: 400px; overflow-y: auto; }
+        #log-table td { text-align: left; }
     </style>
 </head>
 <body>
@@ -97,12 +98,9 @@
         const query = new URLSearchParams({players});
         if (selected) query.append('characters', selected);
 
-        const simRes = await fetch('/simulate?' + query.toString(), {cache: 'no-store'});
-        const simData = await simRes.json();
-        renderLog(simData.log);
-
-        const statsRes = await fetch('/statistics?' + new URLSearchParams({players}).toString(), {cache: 'no-store'});
+        const statsRes = await fetch('/statistics?' + query.toString(), {cache: 'no-store'});
         const statsData = await statsRes.json();
+        renderLog(statsData.log);
         renderTable('matrix-table', statsData.probability_matrix);
         renderTable('details-table', statsData.role_character_stats);
         renderTable('role-table', statsData.role_stats);


### PR DESCRIPTION
## Summary
- enhance compute_statistics to collect logs from all games
- update front‑end to request statistics directly and display full log
- add small style improvement for log table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b753d3548330a4f3fd10cc78b074