### PR TITLE
Improve styling and randomness seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ python main.py
 The script will prompt for the number of players (3 to 7) and
 optionally which characters to use.
 
+By default the simulation uses a random seed generated from the system. To
+reproduce specific results you can set the `BANG_SEED` environment variable
+before running any command:
+
+```bash
+BANG_SEED=123 python main.py
+```
+
 ## Running as a microservice
 
 You can expose the simulation through a simple Flask API with a small
@@ -46,3 +54,13 @@ The API exposes two endpoints:
     character/role pair.
 
 Both endpoints return JSON data suitable for a front‑end.
+
+### Characters in the simulation
+
+The following 14 characters from the base game are currently implemented:
+
+```
+Bart Cassidy, Calamity Janet, Jesse Jones, Lucky Duke, Paul Regret, Sid Ketchum,
+Slab the Killer, Suzy Lafayette, Willy the Kid, El Gringo, Pedro Ramirez,
+Kit Carlson, Rose Doolan, Black Jack
+```

--- a/main.py
+++ b/main.py
@@ -1,9 +1,14 @@
 import random
+import os
 
-# Defina uma semente para tornar a simulacao reproduzivel
-# A semente fixa facilita os testes e depuracao.
-RANDOM_SEED = 42
-random.seed(RANDOM_SEED)
+# Permite definir uma semente via variavel de ambiente.
+# Se nenhuma for informada, usa a aleatoriedade padrao do Python.
+RANDOM_SEED = os.getenv("BANG_SEED")
+if RANDOM_SEED is not None:
+    try:
+        random.seed(int(RANDOM_SEED))
+    except ValueError:
+        random.seed(RANDOM_SEED)
 from utils import build_deck, draw_card, WEAPON_RANGES, CHARACTER_PERKS, CHARACTERS
 from targeting import select_target
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,10 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <title>Bang! Simulação</title>
+    <link href="https://fonts.googleapis.com/css2?family=Rye&display=swap" rel="stylesheet">
     <style>
-        body { font-family: Arial, sans-serif; margin: 2em; }
+        body {
+            font-family: 'Rye', serif;
+            margin: 2em;
+            background-color: #f5f5dc; /* cor bege para lembrar o velho oeste */
+        }
         label { display: block; margin-top: 1em; }
-        select { width: 200px; height: 150px; }
+        select { width: 100%; height: 150px; }
         button { margin-top: 1em; padding: 0.5em 1em; }
         table { border-collapse: collapse; margin-bottom: 1em; }
         th, td { border: 1px solid #ccc; padding: 0.25em 0.5em; text-align: center; }


### PR DESCRIPTION
## Summary
- allow RNG seed via `BANG_SEED` environment variable
- restyle index page with western font and beige background
- make `<select>` stretch to page width
- document seed usage and list available characters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855bcbdb54883308445f102b83905eb